### PR TITLE
Fix em-dash in pytest command in contribution docs

### DIFF
--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -89,7 +89,7 @@ To run tests, first install the test requirements seen in the previous section, 
 
 .. code:: bash
 
-    pytest --cov="<path_to_virtual_environment>\Lib\site-packages\ansys\api\lumerical" --cov="<pylumerical_repository>\tests\unit" --cov-report=html:coverage_report –verbose
+    pytest --cov="<path_to_virtual_environment>\Lib\site-packages\ansys\api\lumerical" --cov="<pylumerical_repository>\tests\unit" --cov-report=html:coverage_report –-verbose
 
 Replace ``<path_to_virtual_environment>`` with the path to your virtual environment, and ``<pylumerical_repository>`` with the path to your local PyLumerical repository.
 


### PR DESCRIPTION
Summary

This PR fixes a small typo in the testing instructions on the contribution page.
The pytest command was using an em-dash (–) before the verbose flag instead of the regular double hyphen (--). This caused the command to fail when copied into a terminal. The typo has now been corrected.

Changes made

Updated –verbose to --verbose in the contribution documentation.

Why this matters

The incorrect dash breaks the command and can confuse contributors who try to run it directly.

Fixes #24.