### PR TITLE
docs: Added syntax highlighting for examples.

### DIFF
--- a/doc/.vale.ini
+++ b/doc/.vale.ini
@@ -35,3 +35,7 @@ Google.WordList = NO
 # Ignore specific tokens for class references and such
 
 TokenIgnores = (:(func|class|meth|attr|py):`(?:.|\n)*?`)|(<.*>)|(\|[A-Za-z0-9_]+\|)
+
+# Autosummary/Jinja templates are implementation files, not prose.
+[source/_templates/**/*.rst]
+BasedOnStyles =

--- a/doc/.vale.ini
+++ b/doc/.vale.ini
@@ -37,5 +37,5 @@ Google.WordList = NO
 TokenIgnores = (:(func|class|meth|attr|py):`(?:.|\n)*?`)|(<.*>)|(\|[A-Za-z0-9_]+\|)
 
 # Autosummary/Jinja templates are implementation files, not prose.
-[source/_templates/**/*.rst]
+[**/source/_templates/**/*.rst]
 BasedOnStyles =

--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -1,0 +1,5 @@
+/* Do not show In [ ]: / Out [ ]: prompt boxes on notebook cells.*/
+.nbinput .prompt,
+.nboutput .prompt {
+    display: none;
+}

--- a/doc/source/_templates/README.md
+++ b/doc/source/_templates/README.md
@@ -1,5 +1,5 @@
 ## Contains templates for the documentation build
 
-- An autosummary template following ansys-sphinx-theme 1.7.2 is used
-    - The ansys-sphinx-theme template doesn't apply to non-html builds (latex/linkcheck), which causes issues in terms of autosummary trying to document `__init__`, when we override it in the Ansys theme.
+- An auto summary template following ansys-sphinx-theme 1.7.2 is used
+    - The ansys-sphinx-theme template doesn't apply to non-html builds (latex/linkcheck), which makes sphinx fall back to the default and tries to document `__init__`, when it's overridden in the Ansys theme.
     - The `__init__` documentation causes errors for PyLumerical, because some of the docstrings are empty or malformed because those aren't meant to be shown/documented anyways.

--- a/doc/source/_templates/README.md
+++ b/doc/source/_templates/README.md
@@ -1,1 +1,5 @@
 ## Contains templates for the documentation build
+
+- An autosummary template following ansys-sphinx-theme 1.7.2 is used
+    - The ansys-sphinx-theme template doesn't apply to non-html builds (latex/linkcheck), which causes issues in terms of autosummary trying to document `__init__`, when we override it in the Ansys theme.
+    - The `__init__` documentation causes errors for PyLumerical, because some of the docstrings are empty or malformed because those aren't meant to be shown/documented anyways.

--- a/doc/source/_templates/autosummary/class.rst
+++ b/doc/source/_templates/autosummary/class.rst
@@ -1,0 +1,32 @@
+{{ objname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+   {% block methods %}
+
+   {% if methods %}
+   .. rubric:: {{ _('Methods') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in methods %}
+      {% if item != "__init__" %}
+      {{ name }}.{{ item }}
+      {% endif %}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in attributes %}
+      {{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/doc/source/api/interface_class.rst
+++ b/doc/source/api/interface_class.rst
@@ -5,7 +5,6 @@ Instances of these objects each represent an interactive session with a Lumerica
 
 .. autosummary::
     :toctree: _autosummary
-    :recursive:
 
     ansys.lumerical.core.FDTD
     ansys.lumerical.core.MODE

--- a/doc/source/changelog/81.documentation.md
+++ b/doc/source/changelog/81.documentation.md
@@ -1,0 +1,1 @@
+Added syntax highlighting for examples.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -178,6 +178,11 @@ def remove_examples_from_source_dir(app, exception):
     shutil.rmtree(source_dir / "examples")
 
 
+def remove_doctree(app, exception):
+    """Remove the .doctrees directory after each builder to ensure a clean environment for the next builder."""
+    shutil.rmtree(app.doctreedir, ignore_errors=True)
+
+
 def copy_examples_to_output_dir(app, exception):
     """Copy examples to output directory."""
     source_dir = pathlib.Path(app.srcdir)
@@ -233,3 +238,4 @@ def setup(app):
         app.connect("build-finished", copy_examples_to_output_dir)
 
     app.connect("autodoc-skip-member", autodoc_skip_member_custom)
+    app.connect("build-finished", remove_doctree, priority=600)  # Needed to avoid orphan stub page problems in CI

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -107,9 +107,6 @@ copybutton_prompt_is_regexp = True
 
 exclude_patterns = ["conf.py", "examples/README.rst"]
 
-# Suppress unpickleable config warning for nbsphinx_custom_formats, necessary for syntax highlighting without execution of notebooks
-suppress_warnings = ["config.cache"]
-
 
 # Skipping members
 def autodoc_skip_member_custom(app, what, name, obj, skip, options):
@@ -118,25 +115,11 @@ def autodoc_skip_member_custom(app, what, name, obj, skip, options):
 
 
 # nbsphinx configurations
-
-
-def _read_py_as_notebook(text):
-    """Convert a Python light-format script to a notebook with language metadata.
-
-    jupytext does not inject kernelspec or language_info when reading a plain
-    .py file without a YAML header. nbsphinx needs language_info.pygments_lexer
-    to select the Pygments lexer; without it rendering defaults to no highlighting.
-    """
-    import jupytext
-
-    nb = jupytext.reads(text, fmt="")
-    nb.metadata.setdefault("kernelspec", {"display_name": "Python 3", "language": "python", "name": "python3"})
-    nb.metadata.setdefault("language_info", {"name": "python", "pygments_lexer": "ipython3"})
-    return nb
-
-
+# Use a 2-element [converter_string, kwargs] form so the value is fully pickleable (no callable).
+# The language_info header is injected into .py files during copy_examples_to_source_dir so that
+# jupytext can populate the pygments_lexer metadata needed for syntax highlighting.
 nbsphinx_execute = "never"
-nbsphinx_custom_formats = {".py": _read_py_as_notebook}
+nbsphinx_custom_formats = {".py": ["jupytext.reads", {}]}
 
 # Conditionally configure nbsphinx_prolog if examples are enabled
 if build_examples:
@@ -179,6 +162,14 @@ def copy_examples_to_source_dir(app):
     source_dir = pathlib.Path(app.srcdir)
 
     shutil.copytree(source_dir.parent.parent / "examples", source_dir / "examples", dirs_exist_ok=True)
+
+
+def add_nb_yaml_header(app):
+    """Prepend jupytext language_info YAML header to .py examples for nbsphinx syntax highlighting."""
+    header = "# ---\n# jupyter:\n#   language_info:\n#     name: python\n#     pygments_lexer: ipython3\n# ---\n\n"
+    source_dir = pathlib.Path(app.srcdir)
+    for py_file in (source_dir / "examples").rglob("*.py"):
+        py_file.write_text(header + py_file.read_text(encoding="utf-8"), encoding="utf-8")
 
 
 def remove_examples_from_source_dir(app, exception):
@@ -237,6 +228,7 @@ def setup(app):
     # Conditionally register example-related handlers if examples are enabled
     if build_examples:
         app.connect("builder-inited", copy_examples_to_source_dir)
+        app.connect("builder-inited", add_nb_yaml_header)
         app.connect("build-finished", remove_examples_from_source_dir)
         app.connect("build-finished", copy_examples_to_output_dir)
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -111,7 +111,12 @@ exclude_patterns = ["conf.py", "examples/README.rst"]
 # Skipping members
 def autodoc_skip_member_custom(app, what, name, obj, skip, options):
     """Skip members that are not intended to be in documentation."""
-    return True if obj.__doc__ is None else None  # need to return none if exclude is false otherwise it will interfere with other skip functions
+    if name.startswith("_"):
+        return True  # Skip internal methods
+    elif obj.__doc__ is None:
+        return True  # Skip members without docstrings
+    else:
+        return None  # need to return none if exclude is false otherwise it will interfere with other skip functions
 
 
 # nbsphinx configurations

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -114,10 +114,26 @@ def autodoc_skip_member_custom(app, what, name, obj, skip, options):
     return True if obj.__doc__ is None else None  # need to return none if exclude is false otherwise it will interfere with other skip functions
 
 
-# nbpsphinx configurations
+# nbsphinx configurations
+
+
+def _read_py_as_notebook(text):
+    """Convert a Python light-format script to a notebook with language metadata.
+
+    jupytext does not inject kernelspec or language_info when reading a plain
+    .py file without a YAML header. nbsphinx needs language_info.pygments_lexer
+    to select the Pygments lexer; without it rendering defaults to no highlighting.
+    """
+    import jupytext
+
+    nb = jupytext.reads(text, fmt="")
+    nb.metadata.setdefault("kernelspec", {"display_name": "Python 3", "language": "python", "name": "python3"})
+    nb.metadata.setdefault("language_info", {"name": "python", "pygments_lexer": "ipython3"})
+    return nb
+
 
 nbsphinx_execute = "never"
-nbsphinx_custom_formats = {".py": ["jupytext.reads", {"fmt": ""}]}
+nbsphinx_custom_formats = {".py": _read_py_as_notebook}
 
 # Conditionally configure nbsphinx_prolog if examples are enabled
 if build_examples:
@@ -181,6 +197,7 @@ rst_prolog += f""".. |supported_lum_release| replace:: {supported_lum_release}""
 
 # static path
 html_static_path = ["_static"]
+html_css_files = ["custom.css"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -87,6 +87,7 @@ numpydoc_validate = True
 numpydoc_validation_checks = {
     "GL06",  # Found unknown section
     "GL07",  # Sections are in the wrong order.
+    "GL08",  # The object does not have a docstring
     "GL09",  # Deprecation warning should precede extended summary
     "GL10",  # reST directives {directives} must be followed by two colons
     "SS01",  # No summary found
@@ -110,12 +111,7 @@ exclude_patterns = ["conf.py", "examples/README.rst"]
 # Skipping members
 def autodoc_skip_member_custom(app, what, name, obj, skip, options):
     """Skip members that are not intended to be in documentation."""
-    if name.startswith("_"):
-        return True  # Skip internal methods
-    elif obj.__doc__ is None:
-        return True  # Skip members without docstrings
-    else:
-        return None  # need to return none if exclude is false otherwise it will interfere with other skip functions
+    return True if obj.__doc__ is None else None  # need to return none if exclude is false otherwise it will interfere with other skip functions
 
 
 # nbsphinx configurations
@@ -123,7 +119,7 @@ def autodoc_skip_member_custom(app, what, name, obj, skip, options):
 # The language_info header is injected into .py files during copy_examples_to_source_dir so that
 # jupytext can populate the pygments_lexer metadata needed for syntax highlighting.
 nbsphinx_execute = "never"
-nbsphinx_custom_formats = {".py": ["jupytext.reads", {}]}
+nbsphinx_custom_formats = {".py": ["jupytext.reads", {"fmt": ""}]}
 
 # Conditionally configure nbsphinx_prolog if examples are enabled
 if build_examples:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -87,7 +87,6 @@ numpydoc_validate = True
 numpydoc_validation_checks = {
     "GL06",  # Found unknown section
     "GL07",  # Sections are in the wrong order.
-    "GL08",  # The object does not have a docstring
     "GL09",  # Deprecation warning should precede extended summary
     "GL10",  # reST directives {directives} must be followed by two colons
     "SS01",  # No summary found

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -107,6 +107,9 @@ copybutton_prompt_is_regexp = True
 
 exclude_patterns = ["conf.py", "examples/README.rst"]
 
+# Suppress unpickleable config warning for nbsphinx_custom_formats, necessary for syntax highlighting without execution of notebooks
+suppress_warnings = ["config.cache"]
+
 
 # Skipping members
 def autodoc_skip_member_custom(app, what, name, obj, skip, options):

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -178,9 +178,15 @@ def remove_examples_from_source_dir(app, exception):
     shutil.rmtree(source_dir / "examples")
 
 
-def remove_doctree(app, exception):
-    """Remove the .doctrees directory after each builder to ensure a clean environment for the next builder."""
+def remove_doctree_and_autosummary(app, exception):
+    """Remove the .doctrees directory and autosummary stubs after each builder.
+
+    This ensures a clean environment for the next builder and prevents current toctree
+    state from causing toc.not_included warnings in subsequent builders.
+    """
     shutil.rmtree(app.doctreedir, ignore_errors=True)
+    autosummary_dir = pathlib.Path(app.srcdir) / "api" / "_autosummary"
+    shutil.rmtree(autosummary_dir, ignore_errors=True)
 
 
 def copy_examples_to_output_dir(app, exception):
@@ -238,4 +244,4 @@ def setup(app):
         app.connect("build-finished", copy_examples_to_output_dir)
 
     app.connect("autodoc-skip-member", autodoc_skip_member_custom)
-    app.connect("build-finished", remove_doctree, priority=600)  # Needed to avoid orphan stub page problems in CI
+    app.connect("build-finished", remove_doctree_and_autosummary, priority=600)  # Needed to avoid orphan stub page problems in CI

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -10,6 +10,8 @@ Example files must be compliant with `PEP8 <https://peps.python.org/pep-0008/>`_
 
 PyLumerical examples uses the "Light" format for jupytext conversion. To write comment cells into your source file, follow the formatting guidelines listed in the `Jupytext documentation <https://jupytext.readthedocs.io/en/latest/formats-scripts.html>`_.
 
+The doc build injects a YAML header, enclosed by `# ---` into each .py file to enable syntax highlighting without running the example. Do not include your own YAML header.
+
 Always ensure that your example files run without errors, and are properly formatted prior to submitting a pull request.
 
 The documentation build process currently does not automatically execute the examples, as such, no outputs are displayed in the resulting documentation pages.


### PR DESCRIPTION
- Added syntax highlighting for examples by adding a yaml header to each example file when the doc is built (does not affect downloaded .py file).
- Added a custom css to hide prompt numbers, which adds clutter (especially when notebook isn't executed). This follows the method in PyAEDT docs (https://github.com/ansys/pyaedt-examples/blob/main/doc/source/_static/css/highlight.css).