### PR TITLE
docs: Fixed cheatsheet formatting

### DIFF
--- a/doc/source/changelog/84.documentation.md
+++ b/doc/source/changelog/84.documentation.md
@@ -1,0 +1,1 @@
+Fixed cheatsheet formatting

--- a/doc/source/cheat_sheet/pylumerical_cheat_sheet.qmd
+++ b/doc/source/cheat_sheet/pylumerical_cheat_sheet.qmd
@@ -1,6 +1,7 @@
 ---
 title: PyLumerical Cheat Sheet
 format: cheat_sheet-pdf
+syntax-highlighting: idiomatic
 params:
   version: v0.1
 footer: PyLumerical


### PR DESCRIPTION
Fixed cheatsheet formatting after CI/CD update which changed quarto version to newest on the pipeline