### PR TITLE
feat: update Python version to 3.14

### DIFF
--- a/.github/workflows/ci_cd_main.yml
+++ b/.github/workflows/ci_cd_main.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  MAIN_PYTHON_VERSION: '3.13'
+  MAIN_PYTHON_VERSION: '3.14'
   LIBRARY_NAME: 'ansys-lumerical-core'
   DOCUMENTATION_CNAME: 'lumerical.docs.pyansys.com'
 

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, reopened, synchronize, edited, labeled, closed]
 
 env:
-  MAIN_PYTHON_VERSION: '3.13'
+  MAIN_PYTHON_VERSION: '3.14'
   LIBRARY_NAME: 'ansys-lumerical-core' # Note that this is duplicated in the build-test-package job
   DOCUMENTATION_CNAME: 'lumerical.docs.pyansys.com' # Note that this is duplicated in the build-test-package job
 

--- a/.github/workflows/common-build-test-package.yml
+++ b/.github/workflows/common-build-test-package.yml
@@ -25,7 +25,7 @@ on:
         required: true
 
 env:
-  MAIN_PYTHON_VERSION: '3.13'
+  MAIN_PYTHON_VERSION: '3.14'
   DOCUMENTATION_CNAME: ${{ inputs.documentation-cname }}
 
 # Disable all default permissions at workflow level for security (least privilege principle)
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'windows-latest']
-        python: ['3.10', '3.11', '3.12', '3.13']
+        python: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: ansys/actions/build-wheelhouse@v10
         with:

--- a/.github/workflows/common-tests-lumerical.yml
+++ b/.github/workflows/common-tests-lumerical.yml
@@ -24,7 +24,7 @@ jobs:
       id-token: write # Required for trusted publisher
       contents: write # Required for GitHub uploads
     env:
-      DOCKER_IMAGE_LUMERICAL_UNIFIED: 'ghcr.io/ansys-internal/lumerical-unified:v252_4'
+      DOCKER_IMAGE_LUMERICAL_UNIFIED: 'ghcr.io/ansys-internal/lumerical-unified:v261_1'
       DOCKER_CONTAINER_LUMERICAL_UNIFIED_NAME: 'lumerical-unified'
     steps:
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,12 @@
 *.pyc
 _build/
 doc/source/api/_autosummary
+
 # Visual studio Code
 .vscode
+
+# macOS
+.DS_Store
 
 # Quarto extension
 doc/source/cheat_sheet/_extensions

--- a/doc/source/changelog/94.added.md
+++ b/doc/source/changelog/94.added.md
@@ -1,0 +1,1 @@
+Update Python version to 3.14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 dependencies = [

--- a/tests/unit/test_app_call.py
+++ b/tests/unit/test_app_call.py
@@ -23,7 +23,7 @@
 """Test the lumapi 'appCall' and 'appCallWithConstructor' objects.
 
 - test 01: Test 'appCall' object with ordered dict properties
-- test 02: Test 'appCall' object raises 'the requested object cannot be created' LumApiError
+- test 02: Misused positional dict to 'appCall' raises LumApiError (exact message is argument-dependent)
 - test 03: Test 'appCallWithConstructor' object 'set' and 'get' methods
 - test 04: Test 'appCallWithConstructor' object raises 'type added doesn't have property' AttributeError
 - test 05: Test 'appCallWithConstructor' object raises 'use an ordered dict for properties' lumWarning
@@ -59,7 +59,12 @@ class TestAppCall:
         setup_fdtd.adddftmonitor(properties=prop_dict)
 
     def test_appcall_raises_obj_cannot_be_created(self, setup_fdtd):
-        """Test 02: Test 'appCall' object raises 'the requested object cannot be created' LumApiError."""
+        """Test 02: Passing a properties dict positionally (not via ``properties=``) is invalid.
+
+        ``appCall`` turns a dict into a list of keys, so Lumerical ``adddftmonitor`` is invoked
+        with the wrong argument shape. The resulting LumApiError text depends on the product
+        version (e.g. object creation failure vs. property set failure on a partially built object).
+        """
         prop_dict = {
             "name": "monitor 2",
             "override global monitor settings": True,
@@ -72,7 +77,11 @@ class TestAppCall:
         with pytest.raises(lumapi.LumApiError) as ex_info:
             setup_fdtd.adddftmonitor(prop_dict)
 
-        assert "error during property initialization, the requested object cannot be created" in str(ex_info.value)
+        msg = str(ex_info.value).lower()
+        assert (
+            "the requested object cannot be created" in msg
+            or "unable to set property" in msg
+        ), ex_info.value
 
     def test_appcallwithconstructor_obj_set_and_get(self, setup_fdtd):
         """Test 03: Test 'appCallWithConstructor' object 'set' and 'get' methods."""

--- a/tests/unit/test_app_call.py
+++ b/tests/unit/test_app_call.py
@@ -78,10 +78,7 @@ class TestAppCall:
             setup_fdtd.adddftmonitor(prop_dict)
 
         msg = str(ex_info.value).lower()
-        assert (
-            "the requested object cannot be created" in msg
-            or "unable to set property" in msg
-        ), ex_info.value
+        assert "the requested object cannot be created" in msg or "unable to set property" in msg, ex_info.value
 
     def test_appcallwithconstructor_obj_set_and_get(self, setup_fdtd):
         """Test 03: Test 'appCallWithConstructor' object 'set' and 'get' methods."""


### PR DESCRIPTION
- Updated Python version in CI workflows to 3.14.
- Added .DS_Store to .gitignore to exclude macOS system files.
- Bump unit test container to `v261_1` release (note this does not change packaged Python from 3.13) 