### PR TITLE
ci: enhance fork safety in CI workflows by adding checks for write permissions. See issue #116

### DIFF
--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -97,9 +97,6 @@ jobs:
 
   build-test-package:
     name: "Build, Test, and Package"
-    needs: changelog-fragment
-    # Still run fork-safe checks when changelog-fragment is skipped on forks.
-    if: always() && (needs.changelog-fragment.result == 'success' || needs.changelog-fragment.result == 'skipped')
     permissions:
       id-token: write # Required for trusted publisher
       contents: write # Required for GitHub uploads and reusable workflow

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -40,7 +40,8 @@ jobs:
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           python-package-name: ${{ env.LIBRARY_NAME }}
-          token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
+          # Forks have no bot token; fall back to GITHUB_TOKEN (dev-mode is dry-run).
+          token: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.PYANSYS_CI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
           dev-mode: ${{ github.ref != 'refs/heads/main' }}
           upload-reports: true
 
@@ -56,6 +57,8 @@ jobs:
        with:
         persist-credentials: false
      - name: "Sync labels"
+       # HACK: skip if contributor does not have write permissions (forks)
+       if: github.event.pull_request.head.repo.full_name == github.repository
        uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1.3.0
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -69,6 +72,8 @@ jobs:
   changelog-fragment:
     name: "Create changelog fragment"
     needs: labeler
+    # Needs write access; skip on forks.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: write # Required to push changelog updates
       pull-requests: write # Required to update PRs
@@ -93,6 +98,8 @@ jobs:
   build-test-package:
     name: "Build, Test, and Package"
     needs: changelog-fragment
+    # Still run fork-safe checks when changelog-fragment is skipped on forks.
+    if: always() && (needs.changelog-fragment.result == 'success' || needs.changelog-fragment.result == 'skipped')
     permissions:
       id-token: write # Required for trusted publisher
       contents: write # Required for GitHub uploads and reusable workflow
@@ -112,7 +119,8 @@ jobs:
     name: "Deploy PR documentation"
     runs-on: ubuntu-latest
     needs: build-test-package
-    if: always() && (needs.build-test-package.result == 'success' || needs.build-test-package.result == 'skipped')
+    # Needs write access and the bot token; skip on forks.
+    if: always() && (needs.build-test-package.result == 'success' || needs.build-test-package.result == 'skipped') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       contents: write # Required to deploy PR documentation
       pull-requests: write # Needed to add comments to the PR when cleaning pull directory

--- a/.github/workflows/common-build-test-package.yml
+++ b/.github/workflows/common-build-test-package.yml
@@ -87,6 +87,8 @@ jobs:
 
   tests:
     needs: wheelhouse
+    # Needs the private Lumerical container and license server; skip on forks.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       id-token: write # Required for trusted publisher
       contents: write # Required by reusable workflow for write operations
@@ -98,6 +100,8 @@ jobs:
   package:
     name: Package library
     needs: [tests, doc-build]
+    # Attestation needs OIDC/write access; skip on forks.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       attestations: write # Required to create attestations

--- a/.github/workflows/common-doc-build-lumerical.yml
+++ b/.github/workflows/common-doc-build-lumerical.yml
@@ -41,7 +41,8 @@ jobs:
 
   doc-build:
     name: "Doc build"
-    if: ${{ !(inputs.skip-doc-build-if-closed && github.event.action == 'closed') }}
+    # Skip closed-PR builds, and forks (no private container or license server).
+    if: ${{ !(inputs.skip-doc-build-if-closed && github.event.action == 'closed') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
     needs: doc-style
     permissions:

--- a/doc/source/changelog/128.maintenance.md
+++ b/doc/source/changelog/128.maintenance.md
@@ -1,0 +1,1 @@
+Enhance fork safety in CI workflows by adding checks for write permissions. See issue #116


### PR DESCRIPTION
Updated multiple workflow files to include conditions that skip certain jobs when running from forks, ensuring that actions requiring write access or private resources are only executed in appropriate contexts. This improves the robustness of the CI/CD process.