### PR TITLE
docs: Fix vale errors

### DIFF
--- a/doc/.vale.ini
+++ b/doc/.vale.ini
@@ -17,7 +17,7 @@ SkippedScopes = script, style, pre, figure
 WordTemplate = \b(?:%s)\b
 
 # List of Packages to be used for our guidelines
-Packages = Google
+Packages = https://github.com/vale-cli/Google/releases/download/v0.6.3/Google.zip
 
 # Define the Ansys vocabulary
 Vocab = ANSYS
@@ -31,8 +31,6 @@ Vale.Terms = NO
 # Remove Google-specific rules for rules that are not applicable
 
 Google.WordList = NO
-Google.WordListCase = NO
-Google.OxfordComma = NO
 
 # Ignore specific tokens for class references and math roles
 

--- a/doc/.vale.ini
+++ b/doc/.vale.ini
@@ -31,6 +31,8 @@ Vale.Terms = NO
 # Remove Google-specific rules for rules that are not applicable
 
 Google.WordList = NO
+Google.WordListCase = NO
+Google.OxfordComma = NO
 
 # Ignore specific tokens for class references and math roles
 

--- a/doc/source/changelog/154.documentation.md
+++ b/doc/source/changelog/154.documentation.md
@@ -1,0 +1,1 @@
+Fix vale errors


### PR DESCRIPTION
A new update for Google style guide has broke the doc style pipeline.

This PR contains two things:

- An addition of a rule we ignore (WordListCase), which is in addition to a rule we already ignore (WordList)
- A temporary addition to ignore Oxford commas, as it flags false positives, e.g. "...for example, multiple polarization or sources." --> there should not be a comma after the "or" yet vale flags this as an warning.